### PR TITLE
[_]: chore/add PR size control

### DIFF
--- a/.github/workflows/pr-size-control.yml
+++ b/.github/workflows/pr-size-control.yml
@@ -1,0 +1,15 @@
+name: PR Size Checker
+on: pull_request
+jobs:
+  check_pr_size:
+    name: Check PR size doesn't break set limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: maidsafe/pr_size_checker@v3
+        with:
+          max_lines_changed: 500
+          target_branch: master


### PR DESCRIPTION
This PR implements a PR size control to check that the PR does not exceed the 500 LOCs changes.