### PR TITLE
[_]: chore/default branch for sonar analysis

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -2,7 +2,7 @@ name: SonarCloud analysis
 
 on:
   push:
-    branches: ['main']
+    branches: ['master']
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:


### PR DESCRIPTION
Use the correct default repository branch for the Sonarcloud analysis by changing from `main` to `master`.