### PR TITLE
Feat/join call

### DIFF
--- a/migrations/20250407041757-add-anonymous-field-to-room-user.js
+++ b/migrations/20250407041757-add-anonymous-field-to-room-user.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const TABLE_NAME = 'room_users';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn(TABLE_NAME, 'anonymous', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn(TABLE_NAME, 'anonymous');
+  },
+};

--- a/src/modules/call/call.controller.ts
+++ b/src/modules/call/call.controller.ts
@@ -118,17 +118,16 @@ export class CallController {
   @ApiInternalServerErrorResponse({ description: 'Internal server error' })
   async joinCall(
     @Param('id') roomId: string,
-    @Body() joinCallDto: JoinCallDto,
     @User() user: UserTokenData['payload'],
+    @Body() joinCallDto?: JoinCallDto,
   ): Promise<JoinCallResponse> {
     const { uuid } = user || {};
-    const { anonymous, name, lastName } = joinCallDto;
 
     return await this.callUseCase.joinCall(roomId, {
       userId: uuid,
-      name,
-      lastName,
-      anonymous,
+      name: joinCallDto?.name,
+      lastName: joinCallDto?.lastName,
+      anonymous: joinCallDto?.anonymous,
     });
   }
 }

--- a/src/modules/call/call.service.ts
+++ b/src/modules/call/call.service.ts
@@ -69,4 +69,22 @@ export class CallService {
 
     return { token, room: newRoom, paxPerCall: meetFeatures.paxPerCall };
   }
+
+  createCallTokenForParticipant(
+    userId: string,
+    roomId: string,
+    isAnonymous: boolean,
+  ) {
+    const token = generateJitsiJWT(
+      {
+        id: userId,
+        email: isAnonymous ? 'anonymous@inxt.com' : 'user@inxt.com',
+        name: isAnonymous ? 'Anonymous' : 'User',
+      },
+      roomId,
+      false,
+    );
+
+    return token;
+  }
 }

--- a/src/modules/call/call.usecase.spec.ts
+++ b/src/modules/call/call.usecase.spec.ts
@@ -1,4 +1,4 @@
-import { createMock } from '@golevelup/ts-jest';
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CallUseCase } from './call.usecase';
 import { CallService } from './call.service';
@@ -7,53 +7,50 @@ import {
   BadRequestException,
   ConflictException,
   InternalServerErrorException,
+  NotFoundException,
 } from '@nestjs/common';
 import { mockCallResponse, mockRoomData, mockUserPayload } from './fixtures';
 import { Room } from '../room/room.domain';
 import { RoomUserUseCase } from '../room/room-user.usecase';
+import { RoomUser } from '../room/room-user.domain';
 
 describe('CallUseCase', () => {
   let callUseCase: CallUseCase;
-  let callService: CallService;
-  let roomUseCase: RoomUseCase;
-  let roomUserUseCase: RoomUserUseCase;
+  let callService: DeepMocked<CallService>;
+  let roomUseCase: DeepMocked<RoomUseCase>;
+  let roomUserUseCase: DeepMocked<RoomUserUseCase>;
 
   beforeEach(async () => {
+    callService = createMock<CallService>();
+    roomUseCase = createMock<RoomUseCase>();
+    roomUserUseCase = createMock<RoomUserUseCase>();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CallUseCase,
         {
           provide: CallService,
-          useValue: {
-            createCallToken: jest.fn(),
-          },
+          useValue: callService,
         },
         {
           provide: RoomUseCase,
-          useValue: {
-            getRoomByHostId: jest.fn(),
-            createRoom: jest.fn(),
-          },
+          useValue: roomUseCase,
         },
         {
           provide: RoomUserUseCase,
-          useValue: {
-            addUserToRoom: jest.fn(),
-          },
+          useValue: roomUserUseCase,
         },
       ],
     }).compile();
 
     callUseCase = module.get<CallUseCase>(CallUseCase);
-    callService = module.get<CallService>(CallService);
-    roomUseCase = module.get<RoomUseCase>(RoomUseCase);
-    roomUserUseCase = module.get<RoomUserUseCase>(RoomUserUseCase);
   });
 
   describe('validateUserHasNoActiveRoom', () => {
     it('should not throw when user has no active room', async () => {
-      const getRoomByHostIdSpy = jest.spyOn(roomUseCase, 'getRoomByHostId');
-      getRoomByHostIdSpy.mockResolvedValueOnce(null);
+      const getRoomByHostIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByHostId')
+        .mockResolvedValueOnce(null);
 
       await expect(
         callUseCase.validateUserHasNoActiveRoom(
@@ -66,8 +63,9 @@ describe('CallUseCase', () => {
     });
 
     it('should throw ConflictException when user already has an active room', async () => {
-      const getRoomByHostIdSpy = jest.spyOn(roomUseCase, 'getRoomByHostId');
-      getRoomByHostIdSpy.mockResolvedValueOnce(createMock<Room>(mockRoomData));
+      const getRoomByHostIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByHostId')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
 
       await expect(
         callUseCase.validateUserHasNoActiveRoom(
@@ -80,8 +78,9 @@ describe('CallUseCase', () => {
     });
 
     it('should throw InternalServerErrorException when an unexpected error occurs', async () => {
-      const getRoomByHostIdSpy = jest.spyOn(roomUseCase, 'getRoomByHostId');
-      getRoomByHostIdSpy.mockRejectedValueOnce(new Error('Database error'));
+      const getRoomByHostIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByHostId')
+        .mockRejectedValueOnce(new Error('Database error'));
 
       await expect(
         callUseCase.validateUserHasNoActiveRoom(
@@ -96,10 +95,12 @@ describe('CallUseCase', () => {
 
   describe('createCallAndRoom', () => {
     it('should create a call token and room successfully', async () => {
-      const createCallTokenSpy = jest.spyOn(callService, 'createCallToken');
-      const createRoomForCallSpy = jest.spyOn(callUseCase, 'createRoomForCall');
-      createCallTokenSpy.mockResolvedValueOnce(mockCallResponse);
-      createRoomForCallSpy.mockResolvedValueOnce();
+      const createCallTokenSpy = jest
+        .spyOn(callService, 'createCallToken')
+        .mockResolvedValueOnce(mockCallResponse);
+      const createRoomForCallSpy = jest
+        .spyOn(callUseCase, 'createRoomForCall')
+        .mockResolvedValueOnce();
 
       const result = await callUseCase.createCallAndRoom(
         mockUserPayload.uuid,
@@ -116,9 +117,10 @@ describe('CallUseCase', () => {
     });
 
     it('should propagate errors from call service', async () => {
-      const createCallTokenSpy = jest.spyOn(callService, 'createCallToken');
       const error = new Error('Failed to create call');
-      createCallTokenSpy.mockRejectedValueOnce(error);
+      const createCallTokenSpy = jest
+        .spyOn(callService, 'createCallToken')
+        .mockRejectedValueOnce(error);
 
       await expect(
         callUseCase.createCallAndRoom(
@@ -133,8 +135,9 @@ describe('CallUseCase', () => {
 
   describe('createRoomForCall', () => {
     it('should create a room for the call successfully', async () => {
-      const createRoomSpy = jest.spyOn(roomUseCase, 'createRoom');
-      createRoomSpy.mockResolvedValueOnce(createMock<Room>(mockRoomData));
+      const createRoomSpy = jest
+        .spyOn(roomUseCase, 'createRoom')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
 
       await callUseCase.createRoomForCall(
         mockCallResponse,
@@ -150,8 +153,9 @@ describe('CallUseCase', () => {
     });
 
     it('should throw ConflictException when room creation fails', async () => {
-      const createRoomSpy = jest.spyOn(roomUseCase, 'createRoom');
-      createRoomSpy.mockRejectedValueOnce(new Error('Room already exists'));
+      const createRoomSpy = jest
+        .spyOn(roomUseCase, 'createRoom')
+        .mockRejectedValueOnce(new Error('Room already exists'));
 
       await expect(
         callUseCase.createRoomForCall(
@@ -205,6 +209,282 @@ describe('CallUseCase', () => {
       expect(() => {
         callUseCase.handleError(error, context);
       }).toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('joinCall', () => {
+    const roomId = 'test-room-id';
+    const userId = 'test-user-id';
+    const userName = 'Test User';
+    const userLastName = 'Last Name';
+    const roomMock = createMock<Room>(mockRoomData);
+    const callToken = 'test-call-token';
+
+    // Create a proper RoomUser mock
+    const roomUserMock = new RoomUser({
+      id: 1,
+      roomId,
+      userId,
+      name: userName,
+      lastName: userLastName,
+      anonymous: false,
+    });
+
+    // Create a proper anonymous RoomUser mock
+    const anonymousUserMock = new RoomUser({
+      id: 2,
+      roomId,
+      userId: 'generated-uuid',
+      name: userName,
+      anonymous: true,
+    });
+
+    it('should successfully join a call with registered user data', async () => {
+      const userData = {
+        userId,
+        name: userName,
+        lastName: userLastName,
+      };
+
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(roomMock);
+      const addUserToRoomSpy = jest
+        .spyOn(roomUserUseCase, 'addUserToRoom')
+        .mockResolvedValueOnce(roomUserMock);
+      const createCallTokenForParticipantSpy = jest
+        .spyOn(callService, 'createCallTokenForParticipant')
+        .mockReturnValueOnce(callToken);
+
+      const result = await callUseCase.joinCall(roomId, userData);
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith(roomId);
+      expect(addUserToRoomSpy).toHaveBeenCalledWith(roomId, {
+        userId,
+        name: userName,
+        lastName: userLastName,
+        anonymous: false,
+      });
+      expect(createCallTokenForParticipantSpy).toHaveBeenCalledWith(
+        userId,
+        roomId,
+        false,
+      );
+      expect(result).toEqual({
+        token: callToken,
+        room: roomId,
+        userId,
+      });
+    });
+
+    it('should successfully join a call as anonymous user', async () => {
+      const userData = {
+        anonymous: true,
+        name: userName,
+      };
+
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(roomMock);
+      const addUserToRoomSpy = jest
+        .spyOn(roomUserUseCase, 'addUserToRoom')
+        .mockResolvedValueOnce(anonymousUserMock);
+      const createCallTokenForParticipantSpy = jest
+        .spyOn(callService, 'createCallTokenForParticipant')
+        .mockReturnValueOnce(callToken);
+
+      const result = await callUseCase.joinCall(roomId, userData);
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith(roomId);
+      expect(addUserToRoomSpy).toHaveBeenCalledWith(
+        roomId,
+        expect.objectContaining({
+          name: userName,
+          anonymous: true,
+        }),
+      );
+      expect(createCallTokenForParticipantSpy).toHaveBeenCalledWith(
+        anonymousUserMock.userId,
+        roomId,
+        true,
+      );
+      expect(result).toEqual({
+        token: callToken,
+        room: roomId,
+        userId: anonymousUserMock.userId,
+      });
+    });
+
+    it('should throw NotFoundException when room does not exist', async () => {
+      const userData = { userId };
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(null);
+
+      await expect(callUseCase.joinCall(roomId, userData)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith(roomId);
+    });
+
+    it('should propagate BadRequestException from roomUserUseCase', async () => {
+      const userData = { userId };
+      const error = new BadRequestException('Invalid user data');
+
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(roomMock);
+      const addUserToRoomSpy = jest
+        .spyOn(roomUserUseCase, 'addUserToRoom')
+        .mockRejectedValueOnce(error);
+
+      await expect(callUseCase.joinCall(roomId, userData)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith(roomId);
+      expect(addUserToRoomSpy).toHaveBeenCalledWith(
+        roomId,
+        expect.objectContaining({
+          userId,
+          anonymous: false,
+        }),
+      );
+    });
+
+    it('should propagate ConflictException from roomUserUseCase', async () => {
+      const userData = { userId };
+      const error = new ConflictException('User already in room');
+
+      roomUseCase.getRoomByRoomId.mockResolvedValueOnce(roomMock);
+      roomUserUseCase.addUserToRoom.mockRejectedValueOnce(error);
+
+      await expect(callUseCase.joinCall(roomId, userData)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('should throw InternalServerErrorException for unknown errors', async () => {
+      const userData = { userId };
+      const error = new Error('Unknown error');
+
+      roomUseCase.getRoomByRoomId.mockResolvedValueOnce(roomMock);
+      roomUserUseCase.addUserToRoom.mockRejectedValueOnce(error);
+
+      await expect(callUseCase.joinCall(roomId, userData)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('processUserData', () => {
+    it('should handle registered user data correctly', async () => {
+      const roomId = 'test-room-id';
+      const userId = 'test-user-id';
+      const name = 'Test User';
+      const lastName = 'Last Name';
+
+      const roomMock = createMock<Room>(mockRoomData);
+      roomUseCase.getRoomByRoomId.mockResolvedValueOnce(roomMock);
+
+      const registeredRoomUser = new RoomUser({
+        id: 1,
+        roomId,
+        userId,
+        name,
+        lastName,
+        anonymous: false,
+      });
+
+      roomUserUseCase.addUserToRoom.mockResolvedValueOnce(registeredRoomUser);
+      const createCallTokenForParticipantSpy = jest
+        .spyOn(callService, 'createCallTokenForParticipant')
+        .mockReturnValueOnce('test-token');
+
+      await callUseCase.joinCall(roomId, {
+        userId,
+        name,
+        lastName,
+        anonymous: false,
+      });
+
+      expect(createCallTokenForParticipantSpy).toHaveBeenCalledWith(
+        userId,
+        roomId,
+        false,
+      );
+    });
+
+    it('should handle anonymous user data correctly', async () => {
+      const roomId = 'test-room-id';
+      const name = 'Anonymous User';
+
+      const roomMock = createMock<Room>(mockRoomData);
+      roomUseCase.getRoomByRoomId.mockResolvedValueOnce(roomMock);
+
+      const anonymousRoomUser = new RoomUser({
+        id: 1,
+        roomId,
+        userId: 'generated-id',
+        name,
+        anonymous: true,
+      });
+
+      const addUserToRoomSpy = jest
+        .spyOn(roomUserUseCase, 'addUserToRoom')
+        .mockResolvedValueOnce(anonymousRoomUser);
+      jest
+        .spyOn(callService, 'createCallTokenForParticipant')
+        .mockReturnValueOnce('test-token');
+
+      await callUseCase.joinCall(roomId, {
+        name,
+        anonymous: true,
+      });
+
+      expect(addUserToRoomSpy).toHaveBeenCalledWith(
+        roomId,
+        expect.objectContaining({
+          name,
+          anonymous: true,
+        }),
+      );
+    });
+
+    it('should generate user ID when userId is not provided', async () => {
+      const roomId = 'test-room-id';
+      const name = 'User without ID';
+
+      const roomMock = createMock<Room>(mockRoomData);
+      roomUseCase.getRoomByRoomId.mockResolvedValueOnce(roomMock);
+
+      const userWithoutId = new RoomUser({
+        id: 1,
+        roomId,
+        userId: 'generated-id',
+        name,
+        anonymous: true,
+      });
+
+      const addUserToRoomSpy = jest
+        .spyOn(roomUserUseCase, 'addUserToRoom')
+        .mockResolvedValueOnce(userWithoutId);
+      jest
+        .spyOn(callService, 'createCallTokenForParticipant')
+        .mockReturnValueOnce('test-token');
+
+      await callUseCase.joinCall(roomId, {
+        name,
+      });
+
+      expect(addUserToRoomSpy).toHaveBeenCalledWith(
+        roomId,
+        expect.objectContaining({
+          name,
+          anonymous: true,
+        }),
+      );
     });
   });
 });

--- a/src/modules/call/call.usecase.spec.ts
+++ b/src/modules/call/call.usecase.spec.ts
@@ -10,11 +10,13 @@ import {
 } from '@nestjs/common';
 import { mockCallResponse, mockRoomData, mockUserPayload } from './fixtures';
 import { Room } from '../room/room.domain';
+import { RoomUserUseCase } from '../room/room-user.usecase';
 
 describe('CallUseCase', () => {
   let callUseCase: CallUseCase;
   let callService: CallService;
   let roomUseCase: RoomUseCase;
+  let roomUserUseCase: RoomUserUseCase;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -33,12 +35,19 @@ describe('CallUseCase', () => {
             createRoom: jest.fn(),
           },
         },
+        {
+          provide: RoomUserUseCase,
+          useValue: {
+            addUserToRoom: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     callUseCase = module.get<CallUseCase>(CallUseCase);
     callService = module.get<CallService>(CallService);
     roomUseCase = module.get<RoomUseCase>(RoomUseCase);
+    roomUserUseCase = module.get<RoomUserUseCase>(RoomUserUseCase);
   });
 
   describe('validateUserHasNoActiveRoom', () => {

--- a/src/modules/call/dto/join-call.dto.ts
+++ b/src/modules/call/dto/join-call.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class JoinCallDto {
+  @ApiPropertyOptional({
+    description: 'Optional name of the user joining the call',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional last name of the user joining the call',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  lastName?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether the user is joining anonymously',
+    type: Boolean,
+    default: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  anonymous?: boolean;
+}
+
+export interface JoinCallResponse {
+  token: string;
+  room: string;
+  userId: string;
+}

--- a/src/modules/room/models/room-user.model.ts
+++ b/src/modules/room/models/room-user.model.ts
@@ -1,0 +1,74 @@
+import {
+  Column,
+  CreatedAt,
+  DataType,
+  Model,
+  PrimaryKey,
+  Table,
+  UpdatedAt,
+  ForeignKey,
+  BelongsTo,
+} from 'sequelize-typescript';
+import { RoomModel } from './room.model';
+
+interface RoomUserModelAttributes {
+  id: number;
+  roomId: string;
+  userId: string;
+  name?: string;
+  lastName?: string;
+  anonymous: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+@Table({
+  tableName: 'room_users',
+  underscored: true,
+})
+export class RoomUserModel extends Model implements RoomUserModelAttributes {
+  @PrimaryKey
+  @Column({
+    type: DataType.BIGINT,
+    autoIncrement: true,
+    primaryKey: true,
+  })
+  id: number;
+
+  @ForeignKey(() => RoomModel)
+  @Column({
+    type: DataType.UUID,
+    allowNull: false,
+  })
+  roomId: string;
+
+  @BelongsTo(() => RoomModel)
+  room: RoomModel;
+
+  @Column({
+    type: DataType.UUID,
+  })
+  userId: string;
+
+  @Column({
+    type: DataType.STRING,
+  })
+  name?: string;
+
+  @Column({
+    type: DataType.STRING,
+  })
+  lastName?: string;
+
+  @Column({
+    type: DataType.BOOLEAN,
+    defaultValue: false,
+  })
+  anonymous: boolean;
+
+  @CreatedAt
+  createdAt?: Date;
+
+  @UpdatedAt
+  updatedAt?: Date;
+}

--- a/src/modules/room/room-user.domain.ts
+++ b/src/modules/room/room-user.domain.ts
@@ -1,0 +1,51 @@
+export interface RoomUserAttributes {
+  id: number;
+  roomId: string;
+  userId: string;
+  name?: string;
+  lastName?: string;
+  anonymous: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export class RoomUser implements RoomUserAttributes {
+  id: number;
+  roomId: string;
+  userId: string;
+  name?: string;
+  lastName?: string;
+  anonymous: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+
+  constructor(attributes: RoomUserAttributes) {
+    Object.assign(this, attributes);
+  }
+
+  toJSON(): Record<string, any> {
+    return {
+      id: this.id,
+      roomId: this.roomId,
+      userId: this.userId,
+      name: this.name,
+      lastName: this.lastName,
+      anonymous: this.anonymous,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  static build(attributes: RoomUserAttributes): RoomUser {
+    return new RoomUser({
+      id: attributes.id,
+      roomId: attributes.roomId,
+      userId: attributes.userId,
+      name: attributes.name,
+      lastName: attributes.lastName,
+      anonymous: attributes.anonymous,
+      createdAt: attributes.createdAt,
+      updatedAt: attributes.updatedAt,
+    });
+  }
+}

--- a/src/modules/room/room-user.repository.spec.ts
+++ b/src/modules/room/room-user.repository.spec.ts
@@ -1,0 +1,221 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SequelizeRoomUserRepository } from './room-user.repository';
+import { RoomUserModel } from './models/room-user.model';
+import { getModelToken } from '@nestjs/sequelize';
+import { RoomUser } from './room-user.domain';
+
+describe('SequelizeRoomUserRepository', () => {
+  let repository: SequelizeRoomUserRepository;
+  let roomUserModel: DeepMocked<typeof RoomUserModel>;
+
+  const mockRoomUserData = {
+    id: 1,
+    roomId: 'test-room-id',
+    userId: 'test-user-id',
+    name: 'Test User',
+    lastName: 'Smith',
+    anonymous: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    roomUserModel = createMock<typeof RoomUserModel>();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SequelizeRoomUserRepository,
+        {
+          provide: getModelToken(RoomUserModel),
+          useValue: roomUserModel,
+        },
+      ],
+    }).compile();
+
+    repository = module.get<SequelizeRoomUserRepository>(
+      SequelizeRoomUserRepository,
+    );
+  });
+
+  describe('Creating a RoomUser', () => {
+    it('When a user joins a room, then the room user is inserted to the DB successfully', async () => {
+      const mockRoomUser = createMock<RoomUserModel>(mockRoomUserData);
+
+      const createRoomUserSpy = jest
+        .spyOn(roomUserModel, 'create')
+        .mockResolvedValueOnce(mockRoomUser);
+
+      const roomUserCreateData = {
+        roomId: 'test-room-id',
+        userId: 'test-user-id',
+        name: 'Test User',
+        lastName: 'Smith',
+        anonymous: false,
+      };
+
+      const result = await repository.create(roomUserCreateData);
+
+      expect(createRoomUserSpy).toHaveBeenCalledWith(roomUserCreateData);
+      expect(result).toBeInstanceOf(RoomUser);
+      expect(result.id).toEqual(mockRoomUserData.id);
+      expect(result.roomId).toEqual(mockRoomUserData.roomId);
+    });
+  });
+
+  describe('Get RoomUser By Id', () => {
+    it('When the room user exists in the DB, then it is returned successfully', async () => {
+      const mockRoomUser = createMock<RoomUserModel>(mockRoomUserData);
+
+      const findRoomUserByIdSpy = jest
+        .spyOn(roomUserModel, 'findByPk')
+        .mockResolvedValueOnce(mockRoomUser);
+
+      const result = await repository.findById(1);
+
+      expect(findRoomUserByIdSpy).toHaveBeenCalledWith(1);
+      expect(result).toBeInstanceOf(RoomUser);
+      expect(result?.id).toEqual(mockRoomUserData.id);
+    });
+
+    it('When the room user does not exist in the DB, then null is returned', async () => {
+      const findRoomUserByIdSpy = jest
+        .spyOn(roomUserModel, 'findByPk')
+        .mockResolvedValueOnce(null);
+
+      const result = await repository.findById(999);
+
+      expect(findRoomUserByIdSpy).toHaveBeenCalledWith(999);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Get RoomUser By User Id And Room Id', () => {
+    it('When the room user exists in the DB, then it is returned successfully', async () => {
+      const mockRoomUser = createMock<RoomUserModel>(mockRoomUserData);
+      const findRoomUserSpy = jest
+        .spyOn(roomUserModel, 'findOne')
+        .mockResolvedValueOnce(mockRoomUser);
+
+      const result = await repository.findByUserIdAndRoomId(
+        'test-user-id',
+        'test-room-id',
+      );
+
+      expect(findRoomUserSpy).toHaveBeenCalledWith({
+        where: {
+          userId: 'test-user-id',
+          roomId: 'test-room-id',
+        },
+      });
+      expect(result).toBeInstanceOf(RoomUser);
+      expect(result?.userId).toEqual(mockRoomUserData.userId);
+      expect(result?.roomId).toEqual(mockRoomUserData.roomId);
+    });
+
+    it('When the room user does not exist in the DB, then null is returned', async () => {
+      const findRoomUserSpy = jest
+        .spyOn(roomUserModel, 'findOne')
+        .mockResolvedValueOnce(null);
+
+      const result = await repository.findByUserIdAndRoomId(
+        'nonexistent',
+        'nonexistent',
+      );
+
+      expect(findRoomUserSpy).toHaveBeenCalledWith({
+        where: {
+          userId: 'nonexistent',
+          roomId: 'nonexistent',
+        },
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Find All RoomUsers By Room Id', () => {
+    it('When users exist in the room, then they are returned successfully', async () => {
+      const mockRoomUsers = [
+        createMock<RoomUserModel>(mockRoomUserData),
+        createMock<RoomUserModel>({
+          ...mockRoomUserData,
+          id: 2,
+          userId: 'user-2',
+        }),
+      ];
+      const findAllRoomUsersSpy = jest
+        .spyOn(roomUserModel, 'findAll')
+        .mockResolvedValueOnce(mockRoomUsers);
+
+      const result = await repository.findAllByRoomId('test-room-id');
+
+      expect(findAllRoomUsersSpy).toHaveBeenCalledWith({
+        where: { roomId: 'test-room-id' },
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBeInstanceOf(RoomUser);
+      expect(result[1]).toBeInstanceOf(RoomUser);
+    });
+  });
+
+  describe('Count RoomUsers By Room Id', () => {
+    it('When users exist in the room, then their count is returned successfully', async () => {
+      const countRoomUsersSpy = jest
+        .spyOn(roomUserModel, 'count')
+        .mockResolvedValueOnce(5);
+
+      const result = await repository.countByRoomId('test-room-id');
+
+      expect(countRoomUsersSpy).toHaveBeenCalledWith({
+        where: { roomId: 'test-room-id' },
+      });
+      expect(result).toEqual(5);
+    });
+  });
+
+  describe('Update RoomUser', () => {
+    it('When the room user exists in the DB, then it is updated successfully', async () => {
+      const updateRoomUserSpy = jest
+        .spyOn(roomUserModel, 'update')
+        .mockResolvedValueOnce([1]);
+
+      await repository.update(1, { name: 'Updated Name' });
+
+      expect(updateRoomUserSpy).toHaveBeenCalledWith(
+        { name: 'Updated Name' },
+        { where: { id: 1 } },
+      );
+    });
+  });
+
+  describe('Delete RoomUser', () => {
+    it('When the room user exists in the DB, then it is deleted successfully', async () => {
+      const deleteRoomUserSpy = jest
+        .spyOn(roomUserModel, 'destroy')
+        .mockResolvedValueOnce(1);
+
+      await repository.delete(1);
+
+      expect(deleteRoomUserSpy).toHaveBeenCalledWith({
+        where: { id: 1 },
+      });
+    });
+  });
+
+  describe('Delete RoomUser By User Id And Room Id', () => {
+    it('When the room user exists in the DB, then it is deleted successfully', async () => {
+      const deleteRoomUserSpy = jest
+        .spyOn(roomUserModel, 'destroy')
+        .mockResolvedValueOnce(1);
+
+      await repository.deleteByUserIdAndRoomId('test-user-id', 'test-room-id');
+
+      expect(deleteRoomUserSpy).toHaveBeenCalledWith({
+        where: {
+          userId: 'test-user-id',
+          roomId: 'test-room-id',
+        },
+      });
+    });
+  });
+});

--- a/src/modules/room/room-user.repository.ts
+++ b/src/modules/room/room-user.repository.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { OmitCreateProperties } from 'src/types/OmitCreateProperties';
+import { RoomUser, RoomUserAttributes } from './room-user.domain';
+import { RoomUserModel } from './models/room-user.model';
+
+@Injectable()
+export class SequelizeRoomUserRepository {
+  constructor(
+    @InjectModel(RoomUserModel)
+    private readonly roomUserModel: typeof RoomUserModel,
+  ) {}
+
+  async create(
+    data: OmitCreateProperties<RoomUserAttributes>,
+  ): Promise<RoomUser> {
+    const roomUser = await this.roomUserModel.create(data);
+    return RoomUser.build(roomUser);
+  }
+
+  async findById(id: number): Promise<RoomUser | null> {
+    const roomUser = await this.roomUserModel.findByPk(id);
+    return roomUser ? RoomUser.build(roomUser) : null;
+  }
+
+  async findByUserIdAndRoomId(
+    userId: string,
+    roomId: string,
+  ): Promise<RoomUser | null> {
+    const roomUser = await this.roomUserModel.findOne({
+      where: { userId, roomId },
+    });
+    return roomUser ? RoomUser.build(roomUser) : null;
+  }
+
+  async findAllByRoomId(roomId: string): Promise<RoomUser[]> {
+    const roomUsers = await this.roomUserModel.findAll({ where: { roomId } });
+    return roomUsers.map((roomUser) => RoomUser.build(roomUser));
+  }
+
+  async countByRoomId(roomId: string): Promise<number> {
+    return this.roomUserModel.count({ where: { roomId } });
+  }
+
+  async update(id: number, data: Partial<RoomUserAttributes>): Promise<void> {
+    await this.roomUserModel.update(data, { where: { id } });
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.roomUserModel.destroy({ where: { id } });
+  }
+
+  async deleteByUserIdAndRoomId(userId: string, roomId: string): Promise<void> {
+    await this.roomUserModel.destroy({ where: { userId, roomId } });
+  }
+}

--- a/src/modules/room/room-user.usecase.spec.ts
+++ b/src/modules/room/room-user.usecase.spec.ts
@@ -1,0 +1,291 @@
+import { createMock } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoomUserUseCase } from './room-user.usecase';
+import { SequelizeRoomUserRepository } from './room-user.repository';
+import { RoomUseCase } from './room.usecase';
+import { RoomUser } from './room-user.domain';
+import { Room } from './room.domain';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+
+jest.mock('uuid');
+
+describe('RoomUserUseCase', () => {
+  let roomUserUseCase: RoomUserUseCase;
+  let roomUserRepository: SequelizeRoomUserRepository;
+  let roomUseCase: RoomUseCase;
+
+  const mockRoomData = {
+    id: 'test-room-id',
+    hostId: 'test-host-id',
+    maxUsersAllowed: 5,
+  };
+
+  const mockRoomUserData = {
+    id: 1,
+    roomId: 'test-room-id',
+    userId: 'test-user-id',
+    name: 'Test User',
+    lastName: 'Smith',
+    anonymous: false,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoomUserUseCase,
+        {
+          provide: SequelizeRoomUserRepository,
+          useValue: {
+            create: jest.fn(),
+            findByUserIdAndRoomId: jest.fn(),
+            findAllByRoomId: jest.fn(),
+            countByRoomId: jest.fn(),
+            deleteByUserIdAndRoomId: jest.fn(),
+          },
+        },
+        {
+          provide: RoomUseCase,
+          useValue: {
+            getRoomByRoomId: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    roomUserUseCase = module.get<RoomUserUseCase>(RoomUserUseCase);
+    roomUserRepository = module.get<SequelizeRoomUserRepository>(
+      SequelizeRoomUserRepository,
+    );
+    roomUseCase = module.get<RoomUseCase>(RoomUseCase);
+
+    (uuidv4 as jest.Mock).mockReturnValue('generated-uuid');
+  });
+
+  describe('Add User To Room', () => {
+    it('When the room does not exist, then a NotFoundException is thrown', async () => {
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        roomUserUseCase.addUserToRoom('nonexistent-room', {
+          userId: 'test-user-id',
+        }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith('nonexistent-room');
+    });
+
+    it('When the room is full, then a BadRequestException is thrown', async () => {
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
+
+      const countByRoomIdSpy = jest
+        .spyOn(roomUserRepository, 'countByRoomId')
+        .mockResolvedValueOnce(5); // Room is full (max 5)
+
+      await expect(
+        roomUserUseCase.addUserToRoom('test-room-id', {
+          userId: 'test-user-id',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith('test-room-id');
+      expect(countByRoomIdSpy).toHaveBeenCalledWith('test-room-id');
+    });
+
+    it('When no userId is provided or user is anonymous, then a UUID is generated', async () => {
+      jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
+
+      jest.spyOn(roomUserRepository, 'countByRoomId').mockResolvedValueOnce(2); // Room has space
+
+      jest
+        .spyOn(roomUserRepository, 'findByUserIdAndRoomId')
+        .mockResolvedValueOnce(null);
+
+      const createSpy = jest
+        .spyOn(roomUserRepository, 'create')
+        .mockResolvedValueOnce(
+          createMock<RoomUser>({
+            ...mockRoomUserData,
+            userId: 'generated-uuid',
+            anonymous: true,
+          }),
+        );
+
+      const result = await roomUserUseCase.addUserToRoom('test-room-id', {
+        anonymous: true,
+      });
+
+      expect(uuidv4).toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roomId: 'test-room-id',
+          userId: 'generated-uuid',
+          anonymous: true,
+        }),
+      );
+      expect(result.userId).toBe('generated-uuid');
+      expect(result.anonymous).toBe(true);
+    });
+
+    it('When the user is already in the room, then a ConflictException is thrown', async () => {
+      jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
+
+      jest.spyOn(roomUserRepository, 'countByRoomId').mockResolvedValueOnce(2); // Room has space
+
+      const findByUserIdAndRoomIdSpy = jest
+        .spyOn(roomUserRepository, 'findByUserIdAndRoomId')
+        .mockResolvedValueOnce(createMock<RoomUser>(mockRoomUserData));
+
+      await expect(
+        roomUserUseCase.addUserToRoom('test-room-id', {
+          userId: 'test-user-id',
+        }),
+      ).rejects.toThrow(ConflictException);
+
+      expect(findByUserIdAndRoomIdSpy).toHaveBeenCalledWith(
+        'test-user-id',
+        'test-room-id',
+      );
+    });
+
+    it('When all conditions are met, then the user is added to the room successfully', async () => {
+      jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
+
+      jest.spyOn(roomUserRepository, 'countByRoomId').mockResolvedValueOnce(2); // Room has space
+
+      jest
+        .spyOn(roomUserRepository, 'findByUserIdAndRoomId')
+        .mockResolvedValueOnce(null);
+
+      const createSpy = jest
+        .spyOn(roomUserRepository, 'create')
+        .mockResolvedValueOnce(createMock<RoomUser>(mockRoomUserData));
+
+      const result = await roomUserUseCase.addUserToRoom('test-room-id', {
+        userId: 'test-user-id',
+        name: 'Test User',
+        lastName: 'Smith',
+      });
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roomId: 'test-room-id',
+          userId: 'test-user-id',
+          name: 'Test User',
+          lastName: 'Smith',
+          anonymous: false,
+        }),
+      );
+      expect(result).toEqual(expect.objectContaining(mockRoomUserData));
+    });
+  });
+
+  describe('Get Users In Room', () => {
+    it('When the room does not exist, then a NotFoundException is thrown', async () => {
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        roomUserUseCase.getUsersInRoom('nonexistent-room'),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith('nonexistent-room');
+    });
+
+    it('When the room exists, then all users in the room are returned', async () => {
+      jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
+
+      const mockUsers = [
+        createMock<RoomUser>(mockRoomUserData),
+        createMock<RoomUser>({ ...mockRoomUserData, id: 2, userId: 'user-2' }),
+      ];
+
+      const findAllByRoomIdSpy = jest
+        .spyOn(roomUserRepository, 'findAllByRoomId')
+        .mockResolvedValueOnce(mockUsers);
+
+      const result = await roomUserUseCase.getUsersInRoom('test-room-id');
+
+      expect(findAllByRoomIdSpy).toHaveBeenCalledWith('test-room-id');
+      expect(result).toEqual(mockUsers);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('Count Users In Room', () => {
+    it('When the room does not exist, then a NotFoundException is thrown', async () => {
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        roomUserUseCase.countUsersInRoom('nonexistent-room'),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith('nonexistent-room');
+    });
+
+    it('When the room exists, then the count of users in the room is returned', async () => {
+      jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
+
+      const countByRoomIdSpy = jest
+        .spyOn(roomUserRepository, 'countByRoomId')
+        .mockResolvedValueOnce(3);
+
+      const result = await roomUserUseCase.countUsersInRoom('test-room-id');
+
+      expect(countByRoomIdSpy).toHaveBeenCalledWith('test-room-id');
+      expect(result).toBe(3);
+    });
+  });
+
+  describe('Remove User From Room', () => {
+    it('When the room does not exist, then a NotFoundException is thrown', async () => {
+      const getRoomByRoomIdSpy = jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        roomUserUseCase.removeUserFromRoom('test-user-id', 'nonexistent-room'),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(getRoomByRoomIdSpy).toHaveBeenCalledWith('nonexistent-room');
+    });
+
+    it('When the room exists, then the user is removed from the room', async () => {
+      jest
+        .spyOn(roomUseCase, 'getRoomByRoomId')
+        .mockResolvedValueOnce(createMock<Room>(mockRoomData));
+
+      const deleteByUserIdAndRoomIdSpy = jest
+        .spyOn(roomUserRepository, 'deleteByUserIdAndRoomId')
+        .mockResolvedValueOnce(undefined);
+
+      await roomUserUseCase.removeUserFromRoom('test-user-id', 'test-room-id');
+
+      expect(deleteByUserIdAndRoomIdSpy).toHaveBeenCalledWith(
+        'test-user-id',
+        'test-room-id',
+      );
+    });
+  });
+});

--- a/src/modules/room/room-user.usecase.ts
+++ b/src/modules/room/room-user.usecase.ts
@@ -1,0 +1,90 @@
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { SequelizeRoomUserRepository } from './room-user.repository';
+import { RoomUser } from './room-user.domain';
+import { v4 as uuidv4 } from 'uuid';
+import { RoomUseCase } from './room.usecase';
+
+@Injectable()
+export class RoomUserUseCase {
+  constructor(
+    private readonly roomUserRepository: SequelizeRoomUserRepository,
+    private readonly roomUseCase: RoomUseCase,
+  ) {}
+
+  async addUserToRoom(
+    roomId: string,
+    userData: {
+      userId?: string;
+      name?: string;
+      lastName?: string;
+      anonymous?: boolean;
+    },
+  ): Promise<RoomUser> {
+    const room = await this.roomUseCase.getRoomByRoomId(roomId);
+    if (!room) {
+      throw new NotFoundException(`Specified room not found`);
+    }
+
+    const currentUsersCount =
+      await this.roomUserRepository.countByRoomId(roomId);
+    if (currentUsersCount >= room.maxUsersAllowed) {
+      throw new BadRequestException('The room is full');
+    }
+
+    const { userId, name, lastName, anonymous = false } = userData;
+    let userIdToUse = userId;
+
+    if (anonymous || !userIdToUse) {
+      userIdToUse = uuidv4();
+    }
+
+    const existingUser = await this.roomUserRepository.findByUserIdAndRoomId(
+      userIdToUse,
+      roomId,
+    );
+
+    if (existingUser) {
+      throw new ConflictException('User is already in this room');
+    }
+
+    return this.roomUserRepository.create({
+      roomId,
+      userId: userIdToUse,
+      name,
+      lastName,
+      anonymous: Boolean(anonymous),
+    });
+  }
+
+  async getUsersInRoom(roomId: string): Promise<RoomUser[]> {
+    const room = await this.roomUseCase.getRoomByRoomId(roomId);
+    if (!room) {
+      throw new NotFoundException(`Specified room not found`);
+    }
+
+    return this.roomUserRepository.findAllByRoomId(roomId);
+  }
+
+  async countUsersInRoom(roomId: string): Promise<number> {
+    const room = await this.roomUseCase.getRoomByRoomId(roomId);
+    if (!room) {
+      throw new NotFoundException(`Specified room not found`);
+    }
+
+    return this.roomUserRepository.countByRoomId(roomId);
+  }
+
+  async removeUserFromRoom(userId: string, roomId: string): Promise<void> {
+    const room = await this.roomUseCase.getRoomByRoomId(roomId);
+    if (!room) {
+      throw new NotFoundException(`Specified room not found`);
+    }
+
+    await this.roomUserRepository.deleteByUserIdAndRoomId(userId, roomId);
+  }
+}

--- a/src/modules/room/room.module.ts
+++ b/src/modules/room/room.module.ts
@@ -3,10 +3,18 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { RoomModel } from './models/room.model';
 import { RoomUseCase } from './room.usecase';
 import { SequelizeRoomRepository } from './room.repository';
+import { RoomUserModel } from './models/room-user.model';
+import { SequelizeRoomUserRepository } from './room-user.repository';
+import { RoomUserUseCase } from './room-user.usecase';
 
 @Module({
-  imports: [SequelizeModule.forFeature([RoomModel])],
-  providers: [RoomUseCase, SequelizeRoomRepository],
-  exports: [RoomUseCase],
+  imports: [SequelizeModule.forFeature([RoomModel, RoomUserModel])],
+  providers: [
+    RoomUseCase,
+    SequelizeRoomRepository,
+    RoomUserUseCase,
+    SequelizeRoomUserRepository,
+  ],
+  exports: [RoomUseCase, RoomUserUseCase],
 })
 export class RoomModule {}

--- a/src/types/OmitCreateProperties.ts
+++ b/src/types/OmitCreateProperties.ts
@@ -1,3 +1,7 @@
 export type OmitCreateProperties<
-  T extends { id: string; createdAt?: Date; updatedAt?: Date },
+  T extends {
+    id: string | number;
+    createdAt?: Date;
+    updatedAt?: Date;
+  },
 > = Pick<T, Exclude<keyof T, 'id' | 'createdAt' | 'updatedAt'>>;


### PR DESCRIPTION
Join call endpoint: `POST /call/:id/users/join`
- Allows users to join a specified call by providing the call ID and optional user details.
- Supports both registered and anonymous users, with appropriate handling for each case.
