### PR TITLE
[_]: fix/allow a way for anon users to leave the call

### DIFF
--- a/src/modules/call/call.controller.ts
+++ b/src/modules/call/call.controller.ts
@@ -32,6 +32,7 @@ import { JoinCallDto, JoinCallResponseDto } from './dto/join-call.dto';
 import { UsersInRoomDto } from '../room/dto/users-in-room.dto';
 import { RoomUserUseCase } from '../room/room-user.usecase';
 import { OptionalAuth } from '../auth/decorators/optional-auth.decorator';
+import { LeaveCallDto } from './dto/leave-call.dto';
 @ApiTags('Call')
 @Controller('call')
 export class CallController {
@@ -160,6 +161,7 @@ export class CallController {
   })
   @ApiBearerAuth()
   @ApiParam({ name: 'id', description: 'Call/Room ID' })
+  @ApiBody({ type: LeaveCallDto, required: false })
   @ApiOkResponse({
     description:
       'Successfully left the call or user was not in the call (idempotent). Response body is empty.',
@@ -171,8 +173,9 @@ export class CallController {
   leaveCall(
     @Param('id') roomId: string,
     @User() user: UserTokenData['payload'],
+    @Body() leaveCallDto?: LeaveCallDto,
   ): Promise<void> {
     const { uuid } = user || {};
-    return this.callUseCase.leaveCall(roomId, uuid);
+    return this.callUseCase.leaveCall(roomId, uuid || leaveCallDto?.userId);
   }
 }

--- a/src/modules/call/call.usecase.spec.ts
+++ b/src/modules/call/call.usecase.spec.ts
@@ -507,6 +507,7 @@ describe('CallUseCase', () => {
     const roomId = 'test-room-id';
     const hostId = 'host-user-id';
     const participantId = 'participant-user-id';
+    const anonymousUserId = 'anonymous-user-id';
     let roomMock: DeepMocked<Room>;
 
     beforeEach(() => {
@@ -515,6 +516,15 @@ describe('CallUseCase', () => {
       roomUserUseCase.removeUserFromRoom.mockResolvedValue();
       roomUseCase.closeRoom.mockResolvedValue();
       roomUseCase.removeRoom.mockResolvedValue();
+    });
+
+    it('should throw BadRequestException when userId is not provided', async () => {
+      await expect(callUseCase.leaveCall(roomId, undefined)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(roomUseCase.getRoomByRoomId).not.toHaveBeenCalled();
+      expect(roomUserUseCase.removeUserFromRoom).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException when room does not exist', async () => {
@@ -605,15 +615,36 @@ describe('CallUseCase', () => {
       expect(roomUseCase.removeRoom).not.toHaveBeenCalled();
     });
 
-    it('should throw NotFoundException when room does not exist', async () => {
-      roomUseCase.getRoomByRoomId.mockResolvedValueOnce(null);
+    it('should successfully leave a call with anonymous user ID', async () => {
+      roomUserUseCase.countUsersInRoom.mockResolvedValueOnce(1);
+
+      await callUseCase.leaveCall(roomId, anonymousUserId);
+
+      expect(roomUseCase.getRoomByRoomId).toHaveBeenCalledWith(roomId);
+      expect(roomUserUseCase.removeUserFromRoom).toHaveBeenCalledWith(
+        anonymousUserId,
+        roomMock,
+      );
+      expect(roomUserUseCase.countUsersInRoom).toHaveBeenCalledWith(roomId);
+    });
+
+    it('should handle errors during leave call operation', async () => {
+      const error = new Error('Database error');
+      roomUseCase.getRoomByRoomId.mockRejectedValueOnce(error);
 
       await expect(
         callUseCase.leaveCall(roomId, participantId),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(InternalServerErrorException);
+    });
 
-      expect(roomUseCase.getRoomByRoomId).toHaveBeenCalledWith(roomId);
-      expect(roomUserUseCase.removeUserFromRoom).not.toHaveBeenCalled();
+    it('should propagate BadRequestException from roomUserUseCase', async () => {
+      const error = new BadRequestException('Invalid user');
+      roomUseCase.getRoomByRoomId.mockResolvedValueOnce(roomMock);
+      roomUserUseCase.removeUserFromRoom.mockRejectedValueOnce(error);
+
+      await expect(
+        callUseCase.leaveCall(roomId, participantId),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/modules/call/dto/leave-call.dto.ts
+++ b/src/modules/call/dto/leave-call.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+
+export class LeaveCallDto {
+  @ApiProperty({
+    description: 'User ID for anonymous users',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  userId?: string;
+}

--- a/src/modules/room/room-user.usecase.spec.ts
+++ b/src/modules/room/room-user.usecase.spec.ts
@@ -303,7 +303,7 @@ describe('RoomUserUseCase', () => {
       });
     });
 
-    it('When users have no avatars, the avatar field should be undefined', async () => {
+    it('When users have no avatars, the avatar field should be null', async () => {
       const mockRoom = new Room(mockRoomData);
       const mockRoomUsers = [new RoomUser(mockRoomUserData)];
       const mockUsers = [
@@ -339,7 +339,7 @@ describe('RoomUserUseCase', () => {
         name: 'Test User',
         lastName: 'Smith',
         anonymous: false,
-        avatar: undefined,
+        avatar: null,
       });
     });
 
@@ -382,7 +382,6 @@ describe('RoomUserUseCase', () => {
         }),
       ];
       const mockUsers = [
-        // Only one user found in the database
         createMockUser({
           uuid: 'test-user-id',
           avatar: 'avatar-path-1',
@@ -432,7 +431,7 @@ describe('RoomUserUseCase', () => {
         name: 'User 2',
         lastName: 'Last 2',
         anonymous: false,
-        avatar: undefined,
+        avatar: null,
       });
     });
   });

--- a/src/modules/room/room-user.usecase.ts
+++ b/src/modules/room/room-user.usecase.ts
@@ -79,7 +79,7 @@ export class RoomUserUseCase {
       name: roomUser.name,
       lastName: roomUser.lastName,
       anonymous: roomUser.anonymous,
-      avatar: userAvatars.get(roomUser.userId),
+      avatar: userAvatars.get(roomUser.userId) || null,
     }));
   }
 


### PR DESCRIPTION
When anonymous users attempted to leave a call they would encounter an error as no userUuid was being provided, the uuid was being extracted from the jwt which anon users do not have. This pr introduces a way for anon users to leave the call by specifying this in the requests body