### PR TITLE
[PB-4411]: fix/update base image in development Dockerfile to non-alpine version

### DIFF
--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.13.1-alpine
+FROM node:22.13.1
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
Update node image to non alpine version, as that meses up newRelic. Not relevant to this project as of yet, but still that was the reason this issue existed (PB-4411)