### PR TITLE
[PB-4278] featur/Add moderator value when join to call

### DIFF
--- a/src/modules/call/call.service.spec.ts
+++ b/src/modules/call/call.service.spec.ts
@@ -85,10 +85,11 @@ describe('Call service', () => {
   });
 
   describe('createCallTokenForParticipant', () => {
-    it('should create a token for a registered user', () => {
+    it('should create a token for a registered user (non-moderator)', () => {
       const userId = 'test-user-id';
       const roomId = 'test-room-id';
       const isAnonymous = false;
+      const isModerator = false;
       const expectedToken = 'test-participant-token';
 
       (jwt.sign as jest.Mock).mockReturnValue(expectedToken);
@@ -97,6 +98,7 @@ describe('Call service', () => {
         userId,
         roomId,
         isAnonymous,
+        isModerator,
       );
 
       expect(result).toStrictEqual({
@@ -106,10 +108,11 @@ describe('Call service', () => {
       expect(jwt.sign).toHaveBeenCalled();
     });
 
-    it('should create a token for an anonymous user', () => {
+    it('should create a token for an anonymous user (non-moderator)', () => {
       const userId = 'anonymous-user-id';
       const roomId = 'test-room-id';
       const isAnonymous = true;
+      const isModerator = false;
       const expectedToken = 'test-anonymous-token';
 
       (jwt.sign as jest.Mock).mockReturnValue(expectedToken);
@@ -118,6 +121,30 @@ describe('Call service', () => {
         userId,
         roomId,
         isAnonymous,
+        isModerator,
+      );
+
+      expect(result).toStrictEqual({
+        appId: 'jitsi-app-id',
+        token: expectedToken,
+      });
+      expect(jwt.sign).toHaveBeenCalled();
+    });
+
+    it('should create a token for a moderator user', () => {
+      const userId = 'moderator-user-id';
+      const roomId = 'test-room-id';
+      const isAnonymous = false;
+      const isModerator = true;
+      const expectedToken = 'test-moderator-token';
+
+      (jwt.sign as jest.Mock).mockReturnValue(expectedToken);
+
+      const result = callService.createCallTokenForParticipant(
+        userId,
+        roomId,
+        isAnonymous,
+        isModerator,
       );
 
       expect(result).toStrictEqual({

--- a/src/modules/call/call.service.ts
+++ b/src/modules/call/call.service.ts
@@ -79,6 +79,7 @@ export class CallService {
     userId: string,
     roomId: string,
     isAnonymous: boolean,
+    isModerator: boolean,
   ) {
     const token = generateJitsiJWT(
       {
@@ -87,7 +88,7 @@ export class CallService {
         name: isAnonymous ? 'Anonymous' : 'User',
       },
       roomId,
-      false,
+      isModerator,
     );
 
     return {

--- a/src/modules/call/call.usecase.spec.ts
+++ b/src/modules/call/call.usecase.spec.ts
@@ -272,6 +272,7 @@ describe('CallUseCase', () => {
         userId,
         roomId,
         false,
+        false,
       );
       expect(result).toEqual({
         token: callToken.token,
@@ -311,6 +312,7 @@ describe('CallUseCase', () => {
         anonymousUserMock.userId,
         roomId,
         true,
+        false,
       );
       expect(result).toEqual({
         token: callToken.token,
@@ -435,6 +437,7 @@ describe('CallUseCase', () => {
       expect(createCallTokenForParticipantSpy).toHaveBeenCalledWith(
         userId,
         roomId,
+        false,
         false,
       );
     });

--- a/src/modules/call/call.usecase.ts
+++ b/src/modules/call/call.usecase.ts
@@ -143,6 +143,7 @@ export class CallUseCase {
       }
 
       const processedUserData = this.processUserData(userData);
+      const isOwner = processedUserData.userId === room.hostId;
 
       const roomUser = await this.roomUserUseCase.addUserToRoom(
         roomId,
@@ -154,6 +155,7 @@ export class CallUseCase {
         roomUser.userId,
         roomId,
         !!roomUser.anonymous,
+        isOwner,
       );
 
       if (processedUserData.userId === room.hostId && room.isClosed) {


### PR DESCRIPTION
**Problem**
- The frontend couldn't distinguish between regular participants and room owners/moderators when users joined Jitsi calls.
- This prevented the activation of moderator-specific features and UI options for room owners, as the backend was only returning basic user information without indicating their role in the call.

**Solution**
- Updated `joinCall` to determine moderator status by comparing user ID with room host ID