### PR TITLE
[_] refactor(room_users): remove incremental ids from room_users

### DIFF
--- a/migrations/20250918134600-rebuild-room-users-table.js
+++ b/migrations/20250918134600-rebuild-room-users-table.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.dropTable('room_users');
+
+    await queryInterface.createTable('room_users', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        allowNull: false,
+        defaultValue: Sequelize.UUIDV4,
+      },
+      room_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'rooms',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.UUID,
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+      last_name: {
+        type: Sequelize.STRING,
+      },
+      anonymous: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addConstraint('room_users', {
+      type: 'unique',
+      fields: ['user_id', 'room_id'],
+      name: 'room_users_user_id_room_id_unique',
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('room_users');
+
+    await queryInterface.createTable('room_users', {
+      id: {
+        type: Sequelize.BIGINT,
+        primaryKey: true,
+        allowNull: false,
+        autoIncrement: true,
+      },
+      room_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'rooms',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.UUID,
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+      last_name: {
+        type: Sequelize.STRING,
+      },
+      anonymous: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addConstraint('room_users', {
+      type: 'unique',
+      fields: ['user_id', 'room_id'],
+      name: 'room_users_user_id_room_id_unique',
+    });
+  },
+};

--- a/src/modules/call/domain/room-user.domain.ts
+++ b/src/modules/call/domain/room-user.domain.ts
@@ -1,5 +1,5 @@
 export interface RoomUserAttributes {
-  id: number;
+  id: string;
   roomId: string;
   userId: string;
   name?: string;
@@ -10,7 +10,7 @@ export interface RoomUserAttributes {
 }
 
 export class RoomUser implements RoomUserAttributes {
-  id: number;
+  id: string;
   roomId: string;
   userId: string;
   name?: string;

--- a/src/modules/call/models/room-user.model.ts
+++ b/src/modules/call/models/room-user.model.ts
@@ -12,7 +12,7 @@ import {
 import { RoomModel } from './room.model';
 
 interface RoomUserModelAttributes {
-  id: number;
+  id: string;
   roomId: string;
   userId: string;
   name?: string;
@@ -26,14 +26,17 @@ interface RoomUserModelAttributes {
   tableName: 'room_users',
   underscored: true,
 })
-export class RoomUserModel extends Model implements RoomUserModelAttributes {
+export class RoomUserModel
+  extends Model<RoomUserModel>
+  implements RoomUserModelAttributes
+{
   @PrimaryKey
   @Column({
-    type: DataType.BIGINT,
-    autoIncrement: true,
+    type: DataType.UUID,
     primaryKey: true,
+    defaultValue: DataType.UUIDV4,
   })
-  id: number;
+  id: string;
 
   @ForeignKey(() => RoomModel)
   @Column({


### PR DESCRIPTION
This PR rebuilds the table room_users so it uses uuid instead of big integers as its primary key.
This table will have a lot of records being created and deleted, so an incremental ids are not ideal.