### PR TITLE
[_]: feat/add-health-check

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@
 import { Logger, Module } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { CallModule } from './modules/call/call.module';
+import { HealthModule } from './modules/health/health.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import configuration from './config/configuration';
 import { SequelizeModule, SequelizeModuleOptions } from '@nestjs/sequelize';
@@ -79,6 +80,7 @@ const defaultDbConfig = (
     }),
     CallModule,
     SharedModule,
+    HealthModule,
   ],
   controllers: [],
   providers: [

--- a/src/externals/avatar/avatar.service.ts
+++ b/src/externals/avatar/avatar.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand, S3Client, HeadBucketCommand } from '@aws-sdk/client-s3';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
@@ -22,6 +22,26 @@ export class AvatarService {
       forcePathStyle:
         this.configService.get('avatar.forcePathStyle') === 'true',
     });
+  }
+
+  async checkBucket(timeoutMs = 1000) {
+    const bucket = this.configService.get<string>('avatar.bucket');
+    const client = this.AvatarS3Instance();
+    const start = Date.now();
+    const head = client.send(
+      new HeadBucketCommand({ Bucket: bucket })
+    );
+
+    const timer = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), timeoutMs),
+    );
+
+    try {
+      await Promise.race([head, timer]);
+      return { status: 'ok', ping: Date.now() - start };
+    } catch (err: any) {
+      return { status: 'error', error: err?.message || String(err) };
+    }
   }
 
   async getDownloadUrl(avatarKey: string): Promise<string> {

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, HttpCode } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { HealthService } from './health.service';
+
+@ApiTags('Health')
+@Controller('healthz')
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Health check endpoint' })
+  @ApiOkResponse({ description: 'Service is healthy' })
+  async health() {
+    return this.healthService.check();
+  }
+}

--- a/src/modules/health/health.module.ts
+++ b/src/modules/health/health.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
+import { AvatarService } from '../../externals/avatar/avatar.service';
+
+@Module({
+  controllers: [HealthController],
+  providers: [HealthService, AvatarService],
+  exports: [HealthService],
+})
+export class HealthModule {}

--- a/src/modules/health/health.service.spec.ts
+++ b/src/modules/health/health.service.spec.ts
@@ -1,0 +1,80 @@
+import { createMock, DeepMocked } from '@golevelup/ts-jest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Sequelize } from 'sequelize-typescript';
+import { AvatarService } from '../../externals/avatar/avatar.service';
+import { HealthService } from './health.service';
+
+describe('HealthService', () => {
+  let service: HealthService;
+  let sequelize: DeepMocked<Sequelize>;
+  let avatarService: DeepMocked<AvatarService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HealthService],
+    })
+      .useMocker(createMock)
+      .compile();
+
+    service = module.get<HealthService>(HealthService);
+    avatarService = module.get<DeepMocked<AvatarService>>(AvatarService)
+    sequelize = module.get<DeepMocked<Sequelize>>(Sequelize);
+  });
+
+  describe('check', () => {
+    it('When DB and S3 succeed, then it returns ok payload', async () => {
+      avatarService.checkBucket.mockResolvedValue({ status: 'ok', ping: 1 });
+      sequelize.authenticate.mockResolvedValue(undefined);
+
+      const result = await service.check();
+
+      expect(result).toStrictEqual({
+        timestamp: expect.any(String),
+        uptime: expect.any(Number),
+        status: 'ok',
+        db: {
+          status: 'ok',
+          ping: expect.any(Number)
+        },
+        s3: {
+          status: 'ok',
+          ping: 1
+        }
+      })
+    });
+
+    it('When DB fails, then it marks degraded and retains S3', async () => {
+      sequelize.authenticate.mockRejectedValue(new Error('db-down'));
+      avatarService.checkBucket.mockResolvedValue({ status: 'ok', ping: 1 });
+
+      const result = await service.check();
+
+      expect(result).toStrictEqual({
+        timestamp: expect.any(String),
+        uptime: expect.any(Number),
+        status: 'degraded',
+        s3: {
+          status: 'ok',
+          ping: 1
+        }
+      })
+    });
+
+    it('When S3 fails, then it marks degraded and retains DB', async () => {
+      avatarService.checkBucket.mockRejectedValue(new Error('failing'));
+      sequelize.authenticate.mockResolvedValue(undefined);
+
+      const result = await service.check();
+
+      expect(result).toStrictEqual({
+        timestamp: expect.any(String),
+        uptime: expect.any(Number),
+        status: 'degraded',
+        db: {
+          status: 'ok',
+          ping: expect.any(Number)
+        },
+      });
+    });
+  });
+});

--- a/src/modules/health/health.service.ts
+++ b/src/modules/health/health.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Sequelize } from 'sequelize-typescript';
+import { AvatarService } from '../../externals/avatar/avatar.service';
+
+@Injectable()
+export class HealthService {
+  private readonly logger = new Logger(HealthService.name);
+
+  constructor(
+    private readonly sequelize: Sequelize, 
+    private readonly avatarService: AvatarService
+  ) {}
+
+  async check() {
+    const uptime = process.uptime();
+    const timestamp = new Date().toISOString();
+
+    const payload: { status: string, uptime: number, timestamp: string } = {
+      status: 'ok',
+      uptime,
+      timestamp,
+    };
+
+    const checks: Array<Promise<any>> = [];
+    const checkNames: string[] = [];
+
+    checkNames.push('db');
+    const dbPromise = (async () => {
+        const start = Date.now();
+        await this.sequelize.authenticate();
+        return { status: 'ok', ping: Date.now() - start };
+    })();
+    checks.push(dbPromise);
+
+    checkNames.push('s3');
+    checks.push(this.avatarService.checkBucket());
+
+    const results = await Promise.allSettled(checks);
+
+    results.forEach((r, idx) => {
+      const name = checkNames[idx];
+      if (r.status === 'fulfilled') {
+        payload[name] = r.value;
+        if (r.value?.status !== 'ok' && payload.status === 'ok') {
+          payload.status = 'degraded';
+        }
+      } else {
+        payload[name] = { status: 'error', error: r.reason?.message || String(r.reason) };
+        if (payload.status === 'ok') payload.status = 'degraded';
+      }
+    });
+
+    this.logger.debug(`Health check performed: ${JSON.stringify(payload)}`);
+    return payload;
+  }
+}

--- a/src/modules/health/health.service.ts
+++ b/src/modules/health/health.service.ts
@@ -2,53 +2,58 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Sequelize } from 'sequelize-typescript';
 import { AvatarService } from '../../externals/avatar/avatar.service';
 
+type CheckResult = { status: 'ok' | 'error' | 'unknown'; ping?: number; error?: string };
+type HealthPayload = {
+  status: 'ok' | 'degraded';
+  uptime: number;
+  timestamp: string;
+  db?: CheckResult;
+  s3?: CheckResult;
+};
+
 @Injectable()
 export class HealthService {
   private readonly logger = new Logger(HealthService.name);
 
   constructor(
-    private readonly sequelize: Sequelize, 
-    private readonly avatarService: AvatarService
+    private readonly sequelize: Sequelize,
+    private readonly avatarService: AvatarService,
   ) {}
 
-  async check() {
-    const uptime = process.uptime();
-    const timestamp = new Date().toISOString();
+  private async checkDb(): Promise<CheckResult> {
+    const start = Date.now();
+    await this.sequelize.authenticate();
+    return { status: 'ok', ping: Date.now() - start };
+  }
 
-    const payload: { status: string, uptime: number, timestamp: string } = {
+  async check(): Promise<HealthPayload> {
+    const payload: HealthPayload = {
       status: 'ok',
-      uptime,
-      timestamp,
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
     };
 
-    const checks: Array<Promise<any>> = [];
-    const checkNames: string[] = [];
+    const checks = {
+      db: this.checkDb(),
+      s3: this.avatarService.checkBucket(),
+    } as const;
 
-    checkNames.push('db');
-    const dbPromise = (async () => {
-        const start = Date.now();
-        await this.sequelize.authenticate();
-        return { status: 'ok', ping: Date.now() - start };
-    })();
-    checks.push(dbPromise);
+    const results = await Promise.allSettled(
+      Object.entries(checks).map(async ([name, promise]) => {
+        const value = await promise;
+        return [name, value] as const;
+      }),
+    );
 
-    checkNames.push('s3');
-    checks.push(this.avatarService.checkBucket());
-
-    const results = await Promise.allSettled(checks);
-
-    results.forEach((r, idx) => {
-      const name = checkNames[idx];
+    for (const r of results) {
       if (r.status === 'fulfilled') {
-        payload[name] = r.value;
-        if (r.value?.status !== 'ok' && payload.status === 'ok') {
-          payload.status = 'degraded';
-        }
+        const [name, value] = r.value;
+        payload[name] = value;
+        if (value.status !== 'ok') payload.status = 'degraded';
       } else {
-        payload[name] = { status: 'error', error: r.reason?.message || String(r.reason) };
-        if (payload.status === 'ok') payload.status = 'degraded';
+        payload.status = 'degraded';
       }
-    });
+    }
 
     this.logger.debug(`Health check performed: ${JSON.stringify(payload)}`);
     return payload;


### PR DESCRIPTION
This pull request adds a comprehensive health check feature to the application, enabling monitoring of both database and S3 avatar bucket connectivity. The health check is exposed via a new endpoint and includes robust error handling and test coverage. The changes are grouped below by theme:

**Health Check Feature Implementation**

* Added a new `HealthModule` with `HealthService` and `HealthController` to provide a `/healthz` endpoint for health checks, reporting status, uptime, and connectivity to DB and S3. (`src/modules/health/health.module.ts`, `src/modules/health/health.controller.ts`, `src/modules/health/health.service.ts`) [[1]](diffhunk://#diff-165b38339def0bc6a802413b24cd7b809748891f3494309b242bd65f7d171a9eR1-R11) [[2]](diffhunk://#diff-36504fbbd7a8a871b87223a0e0f3bc07e1857336a2ae81046601c4fe7afae084R1-R17) [[3]](diffhunk://#diff-edcd31e70cb67bb8e1c859dafae431e83bfb12029de785265288da545dcd4b66R1-R61)
* Integrated `HealthModule` into the main application module, registering it as an import. (`src/app.module.ts`) [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R5) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R83)

**Avatar Service Enhancements**

* Added a `checkBucket` method to `AvatarService` to verify S3 bucket accessibility with timeout support, used by the health check. (`src/externals/avatar/avatar.service.ts`) [[1]](diffhunk://#diff-716f8b1bc678157eb8a9b954f9ee1bcba035932cc6a5ac6d47d3f5cf6a202508L3-R3) [[2]](diffhunk://#diff-716f8b1bc678157eb8a9b954f9ee1bcba035932cc6a5ac6d47d3f5cf6a202508R27-R46)

**Testing**

* Added unit tests for `HealthService` to verify health check logic under normal, degraded, and error conditions. (`src/modules/health/health.service.spec.ts`)