### PR TITLE
[_] add explcit ID for user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.17.0
 LABEL author="internxt"
 
-RUN groupadd -r nodeuser && useradd -r -g nodeuser nodeuser
+RUN groupadd -g 1234 -r nodeuser && useradd  -u 1234 -r -g nodeuser nodeuser
 USER nodeuser
 
 WORKDIR /usr/app

--- a/development.Dockerfile
+++ b/development.Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22.17.0
 
-RUN groupadd -r nodeuser && useradd -r -g nodeuser nodeuser
+RUN groupadd -g 1234 -r nodeuser && useradd  -u 1234 -r -g nodeuser nodeuser
 USER nodeuser
 WORKDIR /usr/app
 


### PR DESCRIPTION
Looks like OVH cluster + Kubernetes is not dealing well with non-numeric users: https://bobcares.com/blog/container-has-runasnonroot-image-non-numeric-user/