### PR TITLE
[PB-6385] Add migration to remove constraint

### DIFF
--- a/migrations/20260520142639-remove-unique-constraint-to-room-users.js
+++ b/migrations/20260520142639-remove-unique-constraint-to-room-users.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const tableName = 'room_users';
+const uniqueConstraintName = 'room_users_user_id_room_id_unique';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+      await queryInterface.removeConstraint(tableName, uniqueConstraintName);
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.addConstraint(tableName, {
+      type: 'unique',
+      fields: ['user_id', 'room_id'],
+      name: uniqueConstraintName,
+    });
+  }
+};


### PR DESCRIPTION
Migration to remove `['user_id', 'room_id']` uniqueness constraint from the database.

To fix user kick out the idea is to:
1. Each joinCall will create a record in the database with (id, user_id, room_id, jitsi_id) and return id to the user ← this is why the constraint should be removed
2. User stores id in sessionStorage
3. When user is kicked out -  Jitsi webhook sends jitsi_id for deletion
4. When user is kicked out - meet-web sends leaveCall with id

3 and 4 will result in deletion of the same line (whichever arrives first) and mostly done for redundancy. 